### PR TITLE
Design feedback

### DIFF
--- a/src/assets/images/dropup-blue.svg
+++ b/src/assets/images/dropup-blue.svg
@@ -1,0 +1,3 @@
+<svg width="12" height="7" viewBox="0 0 12 7" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M11.4673 6L6.23364 1L0.999995 6" stroke="#388DFF"/>
+</svg>

--- a/src/components/AddressInputPanel/address-input-panel.scss
+++ b/src/components/AddressInputPanel/address-input-panel.scss
@@ -4,12 +4,14 @@
   @extend %col-nowrap;
 
   &__input {
-    font-size: .75rem;
+    font-size: 1rem;
     outline: none;
     border: none;
     flex: 1 1 auto;
     width: 0;
     color: $royal-blue;
+    overflow: hidden;
+    text-overflow: ellipsis;
 
     &::placeholder {
       color: $chalice-gray;

--- a/src/components/CurrencyInputPanel/currency-panel.scss
+++ b/src/components/CurrencyInputPanel/currency-panel.scss
@@ -59,6 +59,15 @@
     &--error {
       color: $salmon-red;
     }
+
+    &[type='number'] {
+        -moz-appearance:textfield;
+    }
+
+    &::-webkit-outer-spin-button,
+    &::-webkit-inner-spin-button {
+        -webkit-appearance: none;
+    }
   }
 
   &__extra-text {

--- a/src/components/CurrencyInputPanel/index.js
+++ b/src/components/CurrencyInputPanel/index.js
@@ -272,11 +272,21 @@ class CurrencyInputPanel extends Component {
           <div className="currency-input-panel__input-row">
             <input
               type="number"
+              min="0"
               className={classnames('currency-input-panel__input',{
                 'currency-input-panel__input--error': errorMessage,
               })}
               placeholder="0.0"
               onChange={e => onValueChange(e.target.value)}
+              onKeyPress={e => {
+                const charCode = e.which ? e.which : e.keyCode;
+
+                // Prevent 'minus' character
+                if (charCode === 45) {
+                  e.preventDefault();
+                  e.stopPropagation();
+                }
+              }}
               value={value}
             />
             { this.renderUnlockButton() }

--- a/src/components/CurrencyInputPanel/index.js
+++ b/src/components/CurrencyInputPanel/index.js
@@ -210,15 +210,16 @@ class CurrencyInputPanel extends Component {
       exchangeAddresses: { fromToken },
       web3,
       disableUnlock,
+      value,
     } = this.props;
 
     if (disableUnlock || !selectedTokenAddress || selectedTokenAddress === 'ETH') {
       return;
     }
 
-    const { value, decimals, label } = selectors().getApprovals(selectedTokenAddress, account, fromToken[selectedTokenAddress]);
+    const { value: allowance, decimals, label } = selectors().getApprovals(selectedTokenAddress, account, fromToken[selectedTokenAddress]);
 
-    if (!label || value.isGreaterThan(BN(10 ** 22))) {
+    if (!label || allowance.isGreaterThanOrEqualTo(BN(value * 10 ** decimals || 0))) {
       return;
     }
 

--- a/src/components/Header/header.scss
+++ b/src/components/Header/header.scss
@@ -5,7 +5,7 @@
 
   &__top {
     @extend %row-nowrap;
-    padding: 1.5rem;
+    padding: 1.5rem 1.5rem .5rem 1.5rem;
     align-items: center;
   }
 
@@ -22,7 +22,7 @@
   }
 
   &__navigation {
-    margin: 0 .75rem;
+    margin-bottom: 2rem;
   }
 
   &--inactive {

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -121,11 +121,6 @@ function Header (props) {
         </div>
         <Web3Status isConnected />
       </div>
-      <NavigationTabs
-        className={classnames('header__navigation', {
-          'header--inactive': !props.isConnected,
-        })}
-      />
     </div>
   )
 }

--- a/src/components/TokenLogo/index.js
+++ b/src/components/TokenLogo/index.js
@@ -3,6 +3,14 @@ import PropTypes from 'prop-types';
 import EthereumLogo from '../../assets/images/ethereum-logo.png';
 import GenericTokenLogo from '../../assets/images/generic-token-logo.png';
 
+const RINKEBY_TOKEN_MAP = {
+  '0xDA5B056Cfb861282B4b59d29c9B395bcC238D29B': '0x0d8775f648430679a709e98d2b0cb6250d2887ef',
+  '0x2448eE2641d78CC42D7AD76498917359D961A783': '0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359',
+  '0xF9bA5210F91D0474bd1e1DcDAeC4C58E359AaD85': '0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2',
+  '0x879884c3C46A24f56089f3bBbe4d5e38dB5788C0': '0xd26114cd6ee289accf82350c8d8487fedb8a0c07',
+  '0xF22e3F33768354c9805d046af3C0926f27741B43': '0xe41d2489571d322189246dafa5ebde1f4699f498',
+};
+
 const TOKEN_ICON_API = 'https://raw.githubusercontent.com/TrustWallet/tokens/master/images';
 const BAD_IMAGES = {};
 export default class TokenLogo extends Component {
@@ -14,7 +22,7 @@ export default class TokenLogo extends Component {
 
   static defaultProps = {
     address: '',
-    size: '1.5rem',
+    size: '1rem',
     className: '',
   };
 
@@ -25,13 +33,14 @@ export default class TokenLogo extends Component {
   render() {
     const { address, size, className } = this.props;
     let path = GenericTokenLogo;
+    const mainAddress = RINKEBY_TOKEN_MAP[address] ? RINKEBY_TOKEN_MAP[address] : address;
 
-    if (address === 'ETH') {
+    if (mainAddress === 'ETH') {
       path = EthereumLogo;
     }
 
-    if (!this.state.error && !BAD_IMAGES[address]) {
-      path = `${TOKEN_ICON_API}/${address}.png`;
+    if (!this.state.error && !BAD_IMAGES[mainAddress] && mainAddress !== 'ETH') {
+      path = `${TOKEN_ICON_API}/${mainAddress}.png`;
     }
 
     return (
@@ -44,7 +53,7 @@ export default class TokenLogo extends Component {
         }}
         onError={() => {
           this.setState({ error: true });
-          BAD_IMAGES[address] = true;
+          BAD_IMAGES[mainAddress] = true;
         }}
       />
     );

--- a/src/components/Web3Status/web3-status.scss
+++ b/src/components/Web3Status/web3-status.scss
@@ -7,7 +7,7 @@
   line-height: 1rem;
   align-items: center;
   border: 1px solid $mercury-gray;
-  padding: .5rem 1rem;
+  padding: .5rem;
   border-radius: 2rem;
   color: $dove-gray;
   font-weight: 400;

--- a/src/pages/Pool/AddLiquidity.js
+++ b/src/pages/Pool/AddLiquidity.js
@@ -70,19 +70,19 @@ class AddLiquidity extends Component {
 
   isUnapproved() {
     const { account, exchangeAddresses, selectors } = this.props;
-    const { outputCurrency } = this.state;
+    const { outputCurrency, outputValue } = this.state;
 
     if (!outputCurrency) {
       return false;
     }
 
-    const { value, label } = selectors().getApprovals(
+    const { value: allowance, label, decimals } = selectors().getApprovals(
       outputCurrency,
       account,
       exchangeAddresses.fromToken[outputCurrency]
     );
 
-    if (!label || value.isLessThan(BN(10 ** 22))) {
+    if (label && allowance.isLessThan(BN(outputValue * 10 ** decimals || 0))) {
       return true;
     }
 
@@ -183,8 +183,8 @@ class AddLiquidity extends Component {
     let inputError;
     let outputError;
     let isValid = true;
-    const inputIsZero = BN(inputValue).isEqualTo(BN(0));
-    const outputIsZero = BN(outputValue).isEqualTo(BN(0));
+    const inputIsZero = BN(inputValue).isZero();
+    const outputIsZero = BN(outputValue).isZero();
 
     if (!inputValue || inputIsZero || !outputValue || outputIsZero || !inputCurrency || !outputCurrency || this.isUnapproved()) {
       isValid = false;
@@ -259,8 +259,8 @@ class AddLiquidity extends Component {
       inputCurrency,
       outputCurrency,
     } = this.state;
-    const inputIsZero = BN(inputValue).isEqualTo(BN(0));
-    const outputIsZero = BN(outputValue).isEqualTo(BN(0));
+    const inputIsZero = BN(inputValue).isZero();
+    const outputIsZero = BN(outputValue).isZero();
 
     if (!inputCurrency || !outputCurrency) {
       return (

--- a/src/pages/Send/index.js
+++ b/src/pages/Send/index.js
@@ -74,8 +74,8 @@ class Send extends Component {
     let outputError = '';
     let isValid = true;
     const validRecipientAddress = web3 && web3.utils.isAddress(recipient);
-    const inputIsZero = BN(inputValue).isEqualTo(BN(0));
-    const outputIsZero = BN(outputValue).isEqualTo(BN(0));
+    const inputIsZero = BN(inputValue).isZero();
+    const outputIsZero = BN(outputValue).isZero();
 
     if (!inputValue || inputIsZero || !outputValue || outputIsZero || !inputCurrency || !outputCurrency || !recipient || this.isUnapproved() || !validRecipientAddress) {
       isValid = false;
@@ -100,19 +100,19 @@ class Send extends Component {
 
   isUnapproved() {
     const { account, exchangeAddresses, selectors } = this.props;
-    const { inputCurrency } = this.state;
+    const { inputCurrency, inputValue } = this.state;
 
     if (!inputCurrency || inputCurrency === 'ETH') {
       return false;
     }
 
-    const { value, label } = selectors().getApprovals(
+    const { value: allowance, label, decimals } = selectors().getApprovals(
       inputCurrency,
       account,
       exchangeAddresses.fromToken[inputCurrency]
     );
 
-    if (!label || value.isLessThan(BN(10 ** 22))) {
+    if (label && allowance.isLessThan(BN(inputValue * 10 ** decimals || 0))) {
       return true;
     }
 
@@ -128,7 +128,7 @@ class Send extends Component {
 
     const editedValue = lastEditedField === INPUT ? this.state.inputValue : this.state.outputValue;
 
-    if (BN(editedValue).isEqualTo(BN(0))) {
+    if (BN(editedValue).isZero()) {
       return;
     }
 
@@ -500,8 +500,8 @@ class Send extends Component {
     const { label: inputLabel } = selectors().getBalance(account, inputCurrency);
     const { label: outputLabel } = selectors().getBalance(account, outputCurrency);
     const validRecipientAddress = web3 && web3.utils.isAddress(recipient);
-    const inputIsZero = BN(inputValue).isEqualTo(BN(0));
-    const outputIsZero = BN(outputValue).isEqualTo(BN(0));
+    const inputIsZero = BN(inputValue).isZero();
+    const outputIsZero = BN(outputValue).isZero();
 
     let nextStepMessage;
     if (inputError || outputError) {

--- a/src/pages/Send/index.js
+++ b/src/pages/Send/index.js
@@ -3,12 +3,16 @@ import { drizzleConnect } from 'drizzle-react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import {BigNumber as BN} from "bignumber.js";
+import { CSSTransitionGroup } from "react-transition-group";
 import { selectors } from '../../ducks/web3connect';
 import Header from '../../components/Header';
 import NavigationTabs from '../../components/NavigationTabs';
 import AddressInputPanel from '../../components/AddressInputPanel';
 import CurrencyInputPanel from '../../components/CurrencyInputPanel';
+import Modal from '../../components/Modal';
 import OversizedPanel from '../../components/OversizedPanel';
+import DropdownBlue from "../../assets/images/dropdown-blue.svg";
+import DropupBlue from "../../assets/images/dropup-blue.svg";
 import ArrowDown from '../../assets/images/arrow-down-blue.svg';
 import EXCHANGE_ABI from '../../abi/exchange';
 
@@ -34,6 +38,7 @@ class Send extends Component {
     inputAmountB: '',
     lastEditedField: '',
     recipient: '',
+    showSummaryModal: false,
   };
 
   shouldComponentUpdate(nextProps, nextState) {
@@ -49,6 +54,7 @@ class Send extends Component {
       inputAmountB: '',
       lastEditedField: '',
       recipient: '',
+      showSummaryModal: false,
     });
   }
 
@@ -525,20 +531,129 @@ class Send extends Component {
       )
     }
 
-    const SLIPPAGE = 0.025;
-    const minOutput = BN(outputValue).multipliedBy(1 - SLIPPAGE).toFixed(5);
-    const maxOutput = BN(outputValue).multipliedBy(1 + SLIPPAGE).toFixed(5);
+    return [
+      <div
+        key="open-details"
+        className="swap__summary-wrapper swap__open-details-container"
+        onClick={() => this.setState({showSummaryModal: true})}
+      >
+        <span>Transaction Details</span>
+        <img src={DropdownBlue} />
+      </div>,
+      this.renderSummaryModal()
+    ];
+  }
+
+  renderSummaryModal() {
+    const {
+      inputValue,
+      inputCurrency,
+      inputError,
+      outputValue,
+      outputCurrency,
+      outputError,
+      recipient,
+      showSummaryModal,
+      inputAmountB,
+      lastEditedField,
+    } = this.state;
+    const { selectors, account } = this.props;
+    if (!this.state.showSummaryModal) {
+      return null;
+    }
+
+    const ALLOWED_SLIPPAGE = 0.025;
+    const TOKEN_ALLOWED_SLIPPAGE = 0.04;
+
+    const type = getSendType(inputCurrency, outputCurrency);
+    const { label: inputLabel, decimals: inputDecimals } = selectors().getBalance(account, inputCurrency);
+    const { label: outputLabel, decimals: outputDecimals } = selectors().getBalance(account, outputCurrency);
+
+    const label = lastEditedField === INPUT ? outputLabel : inputLabel;
+    let minOutput;
+    let maxInput;
+
+    if (lastEditedField === INPUT) {
+      switch(type) {
+        case 'ETH_TO_TOKEN':
+          minOutput = BN(outputValue).multipliedBy(1 - ALLOWED_SLIPPAGE).toFixed(5)
+          break;
+        case 'TOKEN_TO_ETH':
+          minOutput = BN(outputValue).multipliedBy(1 - ALLOWED_SLIPPAGE).toFixed(5);
+          break;
+        case 'TOKEN_TO_TOKEN':
+          minOutput = BN(outputValue).multipliedBy(1 - TOKEN_ALLOWED_SLIPPAGE).toFixed(5);
+          break;
+        default:
+          break;
+      }
+    }
+
+    if (lastEditedField === OUTPUT) {
+      switch (type) {
+        case 'ETH_TO_TOKEN':
+          maxInput = BN(inputValue).multipliedBy(1 + ALLOWED_SLIPPAGE).toFixed(5);
+          break;
+        case 'TOKEN_TO_ETH':
+          maxInput = BN(inputValue).multipliedBy(1 + ALLOWED_SLIPPAGE).toFixed(5);
+          break;
+        case 'TOKEN_TO_TOKEN':
+          maxInput = BN(inputValue).multipliedBy(1 + TOKEN_ALLOWED_SLIPPAGE).toFixed(5);
+          break;
+        default:
+          break;
+      }
+    }
+
+    let description;
+    if (lastEditedField === INPUT) {
+      description = (
+        <div>
+          <div>
+            You are selling {b(`${inputValue} ${inputLabel}`)}.
+          </div>
+          <div className="send__last-summary-text">
+            <span className="swap__highlight-text">{recipient.slice(0, 6)}</span> will receive between {b(`${minOutput} ${outputLabel}`)} and {b(`${outputValue} ${outputLabel}`)}.
+          </div>
+        </div>
+      );
+    } else {
+      description = (
+        <div>
+          <div>
+            You are selling between {b(`${inputValue} ${inputLabel}`)} to {b(`${maxInput} ${inputLabel}`)}.
+          </div>
+          <div className="send__last-summary-text">
+            <span className="swap__highlight-text">{recipient.slice(0, 6)}</span> will receive {b(`${outputValue} ${outputLabel}`)}.
+          </div>
+        </div>
+      );
+    }
 
     return (
-      <div className="swap__summary-wrapper">
-        <div>
-          You are selling {b(`${inputValue} ${inputLabel}`)}
-        </div>
-        <div className="send__last-summary-text">
-          <span className="swap__highlight-text">{recipient.slice(0, 6)}</span> will receive between {b(`${minOutput} ${outputLabel}`)} and {b(`${maxOutput} ${outputLabel}`)}
-        </div>
-      </div>
-    )
+      <Modal key="modal" onClose={() => this.setState({ showSummaryModal: false })}>
+        <CSSTransitionGroup
+          transitionName="summary-modal"
+          transitionAppear={true}
+          transitionLeave={true}
+          transitionAppearTimeout={200}
+          transitionLeaveTimeout={200}
+          transitionEnterTimeout={200}
+        >
+          <div className="swap__summary-modal">
+            <div
+              key="open-details"
+              className="swap__open-details-container"
+              onClick={() => this.setState({showSummaryModal: false})}
+            >
+              <span>Transaction Details</span>
+              <img src={DropupBlue} />
+            </div>
+            {description}
+          </div>
+        </CSSTransitionGroup>
+      </Modal>
+    );
   }
 
   renderExchangeRate() {

--- a/src/pages/Swap/index.js
+++ b/src/pages/Swap/index.js
@@ -71,8 +71,8 @@ class Swap extends Component {
     let outputError = '';
     let isValid = true;
     let isUnapproved = this.isUnapproved();
-    const inputIsZero = BN(inputValue).isEqualTo(BN(0));
-    const outputIsZero = BN(outputValue).isEqualTo(BN(0));
+    const inputIsZero = BN(inputValue).isZero();
+    const outputIsZero = BN(outputValue).isZero();
 
     if (!inputValue || inputIsZero || !outputValue || outputIsZero || !inputCurrency || !outputCurrency || isUnapproved) {
       isValid = false;
@@ -97,19 +97,19 @@ class Swap extends Component {
 
   isUnapproved() {
     const { account, exchangeAddresses, selectors } = this.props;
-    const { inputCurrency } = this.state;
+    const { inputCurrency, inputValue } = this.state;
 
     if (!inputCurrency || inputCurrency === 'ETH') {
       return false;
     }
 
-    const { value, label } = selectors().getApprovals(
+    const { value: allowance, label, decmals } = selectors().getApprovals(
       inputCurrency,
       account,
       exchangeAddresses.fromToken[inputCurrency]
     );
 
-    if (!label || value.isLessThan(BN(10 ** 22))) {
+    if (label && allowance.isLessThan(BN(inputValue * 10 ** decimals || 0))) {
       return true;
     }
 
@@ -125,7 +125,7 @@ class Swap extends Component {
 
     const editedValue = lastEditedField === INPUT ? this.state.inputValue : this.state.outputValue;
 
-    if (BN(editedValue).isEqualTo(BN(0))) {
+    if (BN(editedValue).isZero()) {
       return;
     }
 
@@ -483,8 +483,8 @@ class Swap extends Component {
       outputCurrency,
     } = this.state;
 
-    const inputIsZero = BN(inputValue).isEqualTo(BN(0));
-    const outputIsZero = BN(outputValue).isEqualTo(BN(0));
+    const inputIsZero = BN(inputValue).isZero();
+    const outputIsZero = BN(outputValue).isZero();
 
     if (!inputCurrency || !outputCurrency) {
       return (

--- a/src/pages/Swap/swap.scss
+++ b/src/pages/Swap/swap.scss
@@ -11,7 +11,6 @@
 
   &__content {
     padding: 1rem .75rem;
-    margin-top: 1rem;
     flex: 1 1 auto;
     height: 0;
     overflow-y: auto;
@@ -46,7 +45,7 @@
   }
 
   &__summary-wrapper {
-    margin: 2rem 1rem 0;
+    margin: 2rem 1rem;
     color: #737373;
     font-size: .75rem;
     text-align: center;
@@ -54,6 +53,11 @@
 
   &__highlight-text {
     color: $royal-blue;
+  }
+
+  &__cta-container {
+    display: flex;
+    margin-top: 1.5rem;
   }
 
   &__cta-btn {

--- a/src/pages/Swap/swap.scss
+++ b/src/pages/Swap/swap.scss
@@ -51,6 +51,37 @@
     text-align: center;
   }
 
+  &__summary-modal {
+    background-color: $white;
+    position: relative;
+    bottom: 12rem;
+    height: 12rem;
+    z-index: 2000;
+    padding: 1rem;
+    border-top-left-radius: 1rem;
+    border-top-right-radius: 1rem;
+    transition: 250ms ease-in-out;
+
+    .swap__open-details-container {
+      padding: 0.5rem 0;
+      margin-bottom: 1rem;
+    }
+  }
+
+  &__open-details-container {
+    @extend %row-nowrap;
+    align-items: center;
+    justify-content: space-between;
+    padding: .625rem 1rem;
+    font-size: .75rem;
+    color: $royal-blue;
+
+    img {
+      height: .75rem;
+      width: .75rem;
+    }
+  }
+
   &__highlight-text {
     color: $royal-blue;
   }
@@ -72,4 +103,12 @@
   &__sub-text {
     margin-top: 5px;
   }
+}
+
+.summary-modal-appear {
+  bottom: 0;
+}
+
+.summary-modal-appear.modal-container-appear-active {
+  bottom: 0;
 }


### PR DESCRIPTION
# First commit:

* Input Field should preselect to ETH - helps have a single focus for next step
* If input is 0, text should say invalid amount or show the input error state. CTA should be disabled
* token icon should be smaller
* .web3-status padding should be .5rem all around
* CTA button should be disabled if not unlocked
* helper text if not unlocked "Unlock OMG to continue"
* Token address needs space
* Text size too small (recipient text)
* Needs to be disabled until recipient is filled out
* Refactor Send
* Context Help to the Bottom
* Change scroll area so that both switcher and CTA will scroll
* Hardcode Token Icon on test net
* when swapping DAI to ETH, min and max is the same because ETH is so much bigger
* only allow number greater than 0 for currencyInput
* contextual min/max should show estimated input value if last edited field was output

# Second commit:

* min and max in contextual info should change depending on lasteditedfield
* add transaction details modal
