### PR TITLE
Fix approvals

### DIFF
--- a/src/components/CurrencyInputPanel/index.js
+++ b/src/components/CurrencyInputPanel/index.js
@@ -219,7 +219,13 @@ class CurrencyInputPanel extends Component {
 
     const { value: allowance, decimals, label } = selectors().getApprovals(selectedTokenAddress, account, fromToken[selectedTokenAddress]);
 
-    if (!label || allowance.isGreaterThanOrEqualTo(BN(value * 10 ** decimals || 0))) {
+    if (
+      !label ||
+      (
+        allowance.isGreaterThanOrEqualTo(BN((value || 0) * 10 ** decimals)) &&
+        !BN(allowance).isZero()
+      )
+    )  {
       return;
     }
 


### PR DESCRIPTION
Forgot to push this up.

We need to add the extra allowance !== zero because if the allowance is 0 and the value is 0 then the unlock button won't show which is not what we want.