### PR TITLE
Fix max_tokens for initial liquidity provider

### DIFF
--- a/src/pages/Pool/AddLiquidity.js
+++ b/src/pages/Pool/AddLiquidity.js
@@ -160,7 +160,7 @@ class AddLiquidity extends Component {
     const deadline = block.timestamp + 300;
     const MAX_LIQUIDITY_SLIPPAGE = 0.025;
     const minLiquidity = this.isNewExchange() ? BN(0) : liquidityMinted.multipliedBy(1 - MAX_LIQUIDITY_SLIPPAGE);
-    const maxTokens = tokenAmount.multipliedBy(1 + MAX_LIQUIDITY_SLIPPAGE);
+    const maxTokens = this.isNewExchange() ? tokenAmount : tokenAmount.multipliedBy(1 + MAX_LIQUIDITY_SLIPPAGE);
 
     try {
       exchange.methods.addLiquidity(minLiquidity.toFixed(0), maxTokens.toFixed(0), deadline).send({


### PR DESCRIPTION
This oneliner should resolve the initial addLiquidity call surfaced by @haydenadams earlier today.
https://kyokan.slack.com/archives/GD4QV3RE0/p1540838490001500

Uses the same `.isNewExchange()` check as done in `minLiquidity`
/cc @chikeichan