### PR TITLE
Don’t render exchange if no label

### DIFF
--- a/src/pages/Pool/AddLiquidity.js
+++ b/src/pages/Pool/AddLiquidity.js
@@ -333,6 +333,10 @@ class AddLiquidity extends Component {
     const ownedEth = ethPer.multipliedBy(liquidityBalance).dividedBy(10 ** 18);
     const ownedToken = tokenPer.multipliedBy(liquidityBalance).dividedBy(10 ** decimals);
 
+    if (!label) {
+      return blank;
+    }
+
     if (this.isNewExchange()) {
       const rate = BN(outputValue).dividedBy(inputValue);
       const rateText = rate.isNaN() ? '---' : rate.toFixed(4);


### PR DESCRIPTION
The exchange rate now doesn't show if there's no label now.

![](https://duaw26jehqd4r.cloudfront.net/items/2G1Q3Z1k3r02133B4134/Screen%20Recording%202018-11-08%20at%2004.28%20PM.gif?v=c6f5fee4)