### PR TITLE
Normalize remove liquidity exchange rate

### DIFF
--- a/src/pages/Pool/RemoveLiquidity.js
+++ b/src/pages/Pool/RemoveLiquidity.js
@@ -197,7 +197,7 @@ class RemoveLiquidity extends Component {
 
     const ownership = liquidityBalance.dividedBy(totalSupply);
     const ethPer = ethReserve.dividedBy(totalSupply);
-    const tokenPer = tokenReserve.dividedBy(totalSupply);
+    const tokenPer = tokenReserve.multipliedBy(10 ** (18 - tokenDecimals)).dividedBy(totalSupply);
     const exchangeRate = tokenReserve.multipliedBy(10 ** (18 - tokenDecimals)).div(ethReserve);
 
     const ownedEth = ethPer.multipliedBy(liquidityBalance).dividedBy(10 ** 18);

--- a/src/pages/Pool/RemoveLiquidity.js
+++ b/src/pages/Pool/RemoveLiquidity.js
@@ -198,7 +198,7 @@ class RemoveLiquidity extends Component {
     const ownership = liquidityBalance.dividedBy(totalSupply);
     const ethPer = ethReserve.dividedBy(totalSupply);
     const tokenPer = tokenReserve.dividedBy(totalSupply);
-    const exchangeRate = tokenReserve.div(ethReserve);
+    const exchangeRate = tokenReserve.multipliedBy(10 ** (18 - tokenDecimals)).div(ethReserve);
 
     const ownedEth = ethPer.multipliedBy(liquidityBalance).dividedBy(10 ** 18);
     const ownedToken = tokenPer.multipliedBy(liquidityBalance).dividedBy(10 ** tokenDecimals);


### PR DESCRIPTION
The exchange rate for `Remove Liquidity` is now the same as `Add Liquidity`

![](https://cl.ly/e9c45e28870f/Image%2525202018-11-12%252520at%25252012.56.44%252520PM.png)