### PR TITLE
WIP Create getEstimatedGas and use it

### DIFF
--- a/src/helpers/web3-utils.js
+++ b/src/helpers/web3-utils.js
@@ -1,0 +1,31 @@
+import promisify from "./web3-promisfy";
+
+function getBlockNumber(web3) {
+  return promisify(web3, 'getBlockNumber');
+}
+
+function getBlock(web3, blockNumber) {
+  return promisify(web3, 'getBlock', blockNumber);
+}
+
+export async function getEstimatedGas(web3) {
+  const lastBlockNumber = await getBlockNumber(web3);
+  const getBlockPromises = [];
+  for (var i = 0; i < 40; i++) {
+    getBlockPromises.push(getBlock(web3, lastBlockNumber - i));
+  }
+
+  let blocks;
+  try {
+    blocks = await Promise.all(getBlockPromises);
+  } catch (e) {
+    return null;
+  }
+
+  const gasUsed = blocks.map(block => block.gasUsed);
+
+  // Sort then get the 32nd number (the number that covers 80% of cases)
+  // and multiply by 1.25 for a margin of safety.
+  gasUsed.sort((x, y) => x - y);
+  return Math.floor(gasUsed[31] * 1.25);
+}

--- a/src/helpers/web3-utils.js
+++ b/src/helpers/web3-utils.js
@@ -22,8 +22,8 @@ async function calculateEstimatedGas(web3) {
     return null;
   }
 
-  const gasUsed = blocks.map(block => block.gasUsed);
-  gasUsed.sort((x, y) => x - y);
+  const gasUsed = blocks.map(block => block ? block.gasUsed : false);
+  gasUsed.filter(gas => typeof gas === 'number').sort((x, y) => x - y);
 
   const bottomThreeAverage = gasUsed.slice(0, 3).reduce((total, x) => total + x) / 3;
   return Math.floor(bottomThreeAverage);

--- a/src/pages/App.js
+++ b/src/pages/App.js
@@ -4,6 +4,7 @@ import { BrowserRouter, Redirect, Route } from 'react-router-dom';
 import MediaQuery from 'react-responsive';
 import { AnimatedSwitch } from 'react-router-transition';
 import { Web3Connect, startWatching, initialize } from '../ducks/web3connect';
+import { startPollingEstimatedGas } from '../helpers/web3-utils';
 import { setAddresses } from '../ducks/addresses';
 import Header from '../components/Header';
 import Swap from './Swap';
@@ -23,6 +24,10 @@ class App extends Component {
 
     if (this.hasSetNetworkId || !web3 || !web3.eth || !web3.eth.net || !web3.eth.net.getId) {
       return;
+    }
+
+    if (this.props.initialized) {
+      startPollingEstimatedGas(web3);
     }
 
     web3.eth.net.getId((err, networkId) => {

--- a/src/pages/Pool/AddLiquidity.js
+++ b/src/pages/Pool/AddLiquidity.js
@@ -16,6 +16,7 @@ import {BigNumber as BN} from 'bignumber.js';
 import EXCHANGE_ABI from '../../abi/exchange';
 import "./pool.scss";
 import promisify from "../../helpers/web3-promisfy";
+import { getEstimatedGas } from "../../helpers/web3-utils";
 import ReactGA from "react-ga";
 
 const INPUT = 0;
@@ -158,11 +159,13 @@ class AddLiquidity extends Component {
     const MAX_LIQUIDITY_SLIPPAGE = 0.025;
     const minLiquidity = this.isNewExchange() ? BN(0) : liquidityMinted.multipliedBy(1 - MAX_LIQUIDITY_SLIPPAGE);
     const maxTokens = this.isNewExchange() ? tokenAmount : tokenAmount.multipliedBy(1 + MAX_LIQUIDITY_SLIPPAGE);
+    const gas = await getEstimatedGas(web3) || null;
 
     try {
       exchange.methods.addLiquidity(minLiquidity.toFixed(0), maxTokens.toFixed(0), deadline).send({
         from: account,
-        value: ethAmount.toFixed(0)
+        value: ethAmount.toFixed(0),
+        gas
       }, (err, data) => {
         this.reset();
         this.props.addPendingTx(data);

--- a/src/pages/Pool/RemoveLiquidity.js
+++ b/src/pages/Pool/RemoveLiquidity.js
@@ -13,6 +13,7 @@ import ArrowDownBlue from "../../assets/images/arrow-down-blue.svg";
 import ArrowDownGrey from "../../assets/images/arrow-down-grey.svg";
 import EXCHANGE_ABI from "../../abi/exchange";
 import promisify from "../../helpers/web3-promisfy";
+import { getEstimatedGas } from "../../helpers/web3-utils";
 import ReactGA from "react-ga";
 
 class RemoveLiquidity extends Component {
@@ -108,13 +109,14 @@ class RemoveLiquidity extends Component {
     const blockNumber = await promisify(web3, 'getBlockNumber');
     const block = await promisify(web3, 'getBlock', blockNumber);
     const deadline =  block.timestamp + 300;
+    const gas = await getEstimatedGas(web3) || null;
 
     exchange.methods.removeLiquidity(
       amount.toFixed(0),
       ethWithdrawn.multipliedBy(1 - SLIPPAGE).toFixed(0),
       tokenWithdrawn.multipliedBy(1 - SLIPPAGE).toFixed(0),
       deadline,
-    ).send({ from: account }, (err, data) => {
+    ).send({ from: account, gas }, (err, data) => {
       if (data) {
         this.reset();
 

--- a/src/pages/Send/index.js
+++ b/src/pages/Send/index.js
@@ -18,6 +18,7 @@ import EXCHANGE_ABI from '../../abi/exchange';
 
 import "./send.scss";
 import promisify from "../../helpers/web3-promisfy";
+import { getEstimatedGas } from "../../helpers/web3-utils";
 import MediaQuery from "react-responsive";
 import ReactGA from "react-ga";
 
@@ -377,6 +378,7 @@ class Send extends Component {
     const blockNumber = await promisify(web3, 'getBlockNumber');
     const block = await promisify(web3, 'getBlock', blockNumber);
     const deadline =  block.timestamp + 300;
+    const gas = await getEstimatedGas(web3) || null;
 
     if (lastEditedField === INPUT) {
       ReactGA.event({
@@ -396,6 +398,7 @@ class Send extends Component {
             .send({
               from: account,
               value: BN(inputValue).multipliedBy(10 ** 18).toFixed(0),
+              gas
             }, (err, data) => {
               if (!err) {
                 addPendingTx(data);
@@ -412,7 +415,7 @@ class Send extends Component {
               deadline,
               recipient,
             )
-            .send({ from: account }, (err, data) => {
+            .send({ from: account, gas }, (err, data) => {
               if (!err) {
                 addPendingTx(data);
                 this.reset();
@@ -430,7 +433,7 @@ class Send extends Component {
               recipient,
               outputCurrency,
             )
-            .send({ from: account }, (err, data) => {
+            .send({ from: account, gas }, (err, data) => {
               if (!err) {
                 addPendingTx(data);
                 this.reset();
@@ -460,6 +463,7 @@ class Send extends Component {
             .send({
               from: account,
               value: BN(inputValue).multipliedBy(10 ** inputDecimals).multipliedBy(1 + ALLOWED_SLIPPAGE).toFixed(0),
+              gas
             }, (err, data) => {
               if (!err) {
                 addPendingTx(data);
@@ -476,7 +480,7 @@ class Send extends Component {
               deadline,
               recipient,
             )
-            .send({ from: account }, (err, data) => {
+            .send({ from: account, gas }, (err, data) => {
               if (!err) {
                 addPendingTx(data);
                 this.reset();
@@ -498,7 +502,7 @@ class Send extends Component {
               recipient,
               outputCurrency,
             )
-            .send({ from: account }, (err, data) => {
+            .send({ from: account, gas }, (err, data) => {
               if (!err) {
                 addPendingTx(data);
                 this.reset();

--- a/src/pages/Swap/index.js
+++ b/src/pages/Swap/index.js
@@ -19,6 +19,7 @@ import EXCHANGE_ABI from '../../abi/exchange';
 
 import "./swap.scss";
 import promisify from "../../helpers/web3-promisfy";
+import { getEstimatedGas } from "../../helpers/web3-utils";
 
 const INPUT = 0;
 const OUTPUT = 1;
@@ -373,6 +374,7 @@ class Swap extends Component {
     const blockNumber = await promisify(web3, 'getBlockNumber');
     const block = await promisify(web3, 'getBlock', blockNumber);
     const deadline =  block.timestamp + 300;
+    const gas = await getEstimatedGas(web3) || null;
 
     if (lastEditedField === INPUT) {
       // swap input
@@ -380,6 +382,7 @@ class Swap extends Component {
         category: type,
         action: 'SwapInput',
       });
+
       switch(type) {
         case 'ETH_TO_TOKEN':
           // let exchange = new web3.eth.Contract(EXCHANGE_ABI, fromToken[outputCurrency]);
@@ -392,6 +395,7 @@ class Swap extends Component {
             .send({
               from: account,
               value: BN(inputValue).multipliedBy(10 ** 18).toFixed(0),
+              gas,
             }, (err, data) => {
               if (!err) {
                 addPendingTx(data);
@@ -407,7 +411,7 @@ class Swap extends Component {
               BN(outputValue).multipliedBy(10 ** outputDecimals).multipliedBy(1 - ALLOWED_SLIPPAGE).toFixed(0),
               deadline,
             )
-            .send({ from: account }, (err, data) => {
+            .send({ from: account, gas }, (err, data) => {
               if (!err) {
                 addPendingTx(data);
                 this.reset();
@@ -424,7 +428,7 @@ class Swap extends Component {
               deadline,
               outputCurrency,
             )
-            .send({ from: account }, (err, data) => {
+            .send({ from: account, gas }, (err, data) => {
               if (!err) {
                 addPendingTx(data);
                 this.reset();
@@ -453,6 +457,7 @@ class Swap extends Component {
             .send({
               from: account,
               value: BN(inputValue).multipliedBy(10 ** inputDecimals).multipliedBy(1 + ALLOWED_SLIPPAGE).toFixed(0),
+              gas
             }, (err, data) => {
               if (!err) {
                 addPendingTx(data);
@@ -468,7 +473,7 @@ class Swap extends Component {
               BN(inputValue).multipliedBy(10 ** inputDecimals).multipliedBy(1 + ALLOWED_SLIPPAGE).toFixed(0),
               deadline,
             )
-            .send({ from: account }, (err, data) => {
+            .send({ from: account, gas }, (err, data) => {
               if (!err) {
                 addPendingTx(data);
                 this.reset();
@@ -489,7 +494,7 @@ class Swap extends Component {
               deadline,
               outputCurrency,
             )
-            .send({ from: account }, (err, data) => {
+            .send({ from: account, gas }, (err, data) => {
               if (!err) {
                 addPendingTx(data);
                 this.reset();


### PR DESCRIPTION
This PR creates a method called `getEstimatedGas` and uses it for swap/send/add/remove liquidity.

`getEstimatedGas` gets the lowest 3 gas used from the blocks, then averages them. This usually comes out to $0.4-$0.8. Any other calculation method always resulted in a much higher gas fee ($3-$8)