### PR TITLE
Make Swap input’s Balance text act as a “Set max” button

### DIFF
--- a/src/components/CurrencyInputPanel/currency-panel.scss
+++ b/src/components/CurrencyInputPanel/currency-panel.scss
@@ -33,6 +33,9 @@
     font-size: .75rem;
     line-height: 1rem;
     padding: .75rem 1rem;
+    &--clickable-extra-text {
+      padding: .375rem .625rem .375rem 1rem;
+    }
   }
 
   &__label-container {
@@ -72,6 +75,18 @@
   }
 
   &__extra-text {
+    &--clickable {
+      border-radius: 0.5rem;
+      cursor: pointer;
+      padding: .1875rem 0.375rem;
+
+      &:hover {
+        background-color: $concrete-gray;
+      }
+      &:active {
+        background-color: rgba($zumthor-blue, .8);
+      }
+    }
     &--error {
       color: $salmon-red;
     }

--- a/src/components/CurrencyInputPanel/index.js
+++ b/src/components/CurrencyInputPanel/index.js
@@ -59,6 +59,7 @@ class CurrencyInputPanel extends Component {
     filteredTokens: PropTypes.arrayOf(PropTypes.string),
     disableUnlock: PropTypes.bool,
     renderInput: PropTypes.func,
+    onClickExtraText: PropTypes.func,
   };
 
   static defaultProps = {
@@ -367,10 +368,11 @@ class CurrencyInputPanel extends Component {
 
   render() {
     const {
-      title,
       description,
-      extraText,
       errorMessage,
+      extraText,
+      onClickExtraText,
+      title,
     } = this.props;
 
     return (
@@ -378,14 +380,21 @@ class CurrencyInputPanel extends Component {
         <div className={classnames('currency-input-panel__container', {
           'currency-input-panel__container--error': errorMessage,
         })}>
-          <div className="currency-input-panel__label-row">
+          <div className={classnames('currency-input-panel__label-row', {
+            'currency-input-panel__label-row--clickable-extra-text': !!onClickExtraText,
+          })}>
             <div className="currency-input-panel__label-container">
               <span className="currency-input-panel__label">{title}</span>
               <span className="currency-input-panel__label-description">{description}</span>
             </div>
-            <span className={classnames('currency-input-panel__extra-text', {
-              'currency-input-panel__extra-text--error': errorMessage,
-            })}>
+            <span
+              className={classnames('currency-input-panel__extra-text', {
+                'currency-input-panel__extra-text--clickable': !!onClickExtraText,
+                'currency-input-panel__extra-text--error': errorMessage,
+              })}
+              onClick={onClickExtraText}
+              title={!!onClickExtraText ? 'Set max' : null}
+            >
               {extraText}
             </span>
           </div>

--- a/src/pages/Swap/index.js
+++ b/src/pages/Swap/index.js
@@ -673,6 +673,8 @@ class Swap extends Component {
 
     const { inputError, outputError, isValid } = this.validate();
 
+    const InputBalance = inputBalance.dividedBy(BN(10 ** inputDecimals));
+
     return (
       <div className="swap">
         <MediaQuery query="(max-device-width: 767px)">
@@ -692,9 +694,10 @@ class Swap extends Component {
             title="Input"
             description={lastEditedField === OUTPUT ? estimatedText : ''}
             extraText={inputCurrency
-              ? `Balance: ${inputBalance.dividedBy(BN(10 ** inputDecimals)).toFixed(4)}`
+              ? `Balance: ${InputBalance.toFixed(4)}`
               : ''
             }
+            onClickExtraText={() => this.updateInput(InputBalance)}
             onCurrencySelected={inputCurrency => this.setState({ inputCurrency }, this.recalcForm)}
             onValueChange={this.updateInput}
             selectedTokens={[inputCurrency, outputCurrency]}


### PR DESCRIPTION
Fixes https://github.com/Uniswap/uniswap-frontend/issues/154

mobile:
![](https://cl.ly/40d47204eab7/download/uniswap_max.gif)

desktop: 
![](https://cl.ly/58fd11c8b1bb/download/uniswap_max_desktop.gif)