### PR TITLE
fix too thin font-weight in currency-panel

### DIFF
--- a/src/components/CurrencyInputPanel/currency-panel.scss
+++ b/src/components/CurrencyInputPanel/currency-panel.scss
@@ -251,7 +251,6 @@
 
   &__token-label {
     color: $dove-gray;
-    font-weight: 200;
   }
 
   @media only screen and (min-device-width : 768px) {


### PR DESCRIPTION
![image from ios](https://user-images.githubusercontent.com/8116716/50611996-b42bb980-0ed8-11e9-8a20-39a8cb4413b1.jpg)

reverting this font-weight change because it’s really ugly @mikedemarais 