### PR TITLE
No more MetaMask flash! "No Ethereum wallet  found" > priority than "wrong network"

### DIFF
--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -81,6 +81,7 @@ class BlockingWarning extends Component {
       t,
       isConnected,
       initialized,
+      networkIdSet,
       networkId,
     } = this.props;
     let content = [];
@@ -88,18 +89,10 @@ class BlockingWarning extends Component {
     const correctNetworkId = process.env.REACT_APP_NETWORK_ID || 1;
     const correctNetwork = process.env.REACT_APP_NETWORK || 'Main Ethereum Network';
 
-    const wrongNetwork = networkId != correctNetworkId;
+    const wrongNetwork = networkId != correctNetworkId && networkId !== 0;
 
-    if (wrongNetwork && initialized) {
-      content = [
-        <div key="warning-title">{t("wrongNetwork")}</div>,
-        <div key="warning-desc" className="header__dialog__description">
-          {t("switchNetwork", {correctNetwork})}
-        </div>,
-      ];
-    }
-
-    if (!isConnected && initialized) {
+    if (!isConnected && initialized && networkIdSet !== 2) {
+    
       content = [
         <div key="warning-title">{t("noWallet")}</div>,
         <div key="warning-desc" className="header__dialog__description">
@@ -125,8 +118,20 @@ class BlockingWarning extends Component {
                 ]
               )
           }
-        </div>,
+        </div>
       ];
+   
+    } else if (wrongNetwork && initialized) {
+        content = [
+          <div key="warning-title">{t("wrongNetwork")}</div>,
+          <div key="warning-desc" className="header__dialog__description">
+            {t("switchNetwork", {correctNetwork})}
+          </div>,
+        ];
+    }
+
+    if(content.length === 0) {
+      return false;
     }
 
     return (
@@ -142,6 +147,7 @@ class BlockingWarning extends Component {
 }
 
 function Header (props) {
+
   return (
     <div className="header">
       <BlockingWarning {...props} />
@@ -169,6 +175,7 @@ export default connect(
   state => ({
     currentAddress: state.web3connect.account,
     initialized: state.web3connect.initialized,
+    networkIdSet: state.web3connect.networkIdSet,
     isConnected: !!state.web3connect.account,
     web3: state.web3connect.web3,
     networkId: state.web3connect.networkId,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1994,6 +1994,11 @@ brorand@^1.0.1:
   resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
   integrity sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=
 
+browser-process-hrtime@^0.1.2:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz#616f00faef1df7ec1b5bf9cfe2bdc3170f26c7b4"
+  integrity sha512-bRFnI4NnjO6cnyLmOV/7PVoDEMJChlcfN0z4s1YMBY989/SvlfMI1lgCnkFUs53e9gQF+w7qu7XdllSTiSl8Aw==
+
 browser-resolve@^1.11.3:
   version "1.11.3"
   resolved "https://registry.yarnpkg.com/browser-resolve/-/browser-resolve-1.11.3.tgz#9b7cbb3d0f510e4cb86bdbd796124d28b5890af6"


### PR DESCRIPTION
So I have fixed 2 things in this PR:
1. There was missing logic for displaying the _no Ethereum wallet_ / _wrong network_ warnings.
    -   I have added `networkIdSet` state to track _**when web3 is initialised but is yet to connect to a network**_. This missing piece of logic was causing the "no Ethereum wallet" message to flash **Every Time** an Ethereum supported browser visited the page. Not good. This ruined the experience somewhat.
        - `networkIdSet` values:
            - `0`: no networkId set (default)
            - `1`: networkId has been set and is connected (final)
            - `2`: web3 initialised. network is connecting and waiting for networkId response (intermediate)

2. The _Wrong Network_  warning:
    - was taking precedence over the No Ethereum wallet. This does not make much sense - of course, there will be no network at all if no web3 support is present.
    - Even when no network present (networkId === 0), wrong network would display. Wrong network suggests _there is a network_,  but is connected to the wrong one. Hence, networkId of zero does not fall into this logic.

**Note**: If web3 does not exist, an error is displayed in the console stating Swap requires web3. 

Happy to review and change syntax.

### Demo:
No flash -> flash -> flash -> no flash

![flashing](http://jkrb.stream/misc/warningFlashes.gif)
