### PR TITLE
fix: incorrect homepage path in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "uniswap",
   "description": "Uniswap Exchange Protocol",
   "version": "0.1.0",
-  "homepage": ".",
+  "homepage": "https://uniswap.exchange",
   "private": true,
   "dependencies": {
     "@reach/dialog": "^0.2.8",


### PR DESCRIPTION
As mentioned in the issue, accessing `/create-exchange/<address>` in production results in a crash:
https://uniswap.exchange/create-exchange/0x4a57E687b9126435a9B19E4A802113e266AdeBde
PR preview:
https://deploy-preview-335--uniswap.netlify.com/create-exchange/0x4a57E687b9126435a9B19E4A802113e266AdeBde