### PR TITLE
Enable Frame Busting

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,3 +3,10 @@
   from = "/*"
   to = "/index.html"
   status = 200
+
+[[headers]]
+  for = "/*"
+
+  [headers.values]
+    X-Frame-Options = "DENY"
+    Content-Security-Policy = "frame-ancestors https://uniswap.exchange"

--- a/src/pages/App.js
+++ b/src/pages/App.js
@@ -32,6 +32,10 @@ const Body = styled.div`
 `
 
 export default function App() {
+  // Bust out of a frame if in one
+  if (window.top !== window.self) {
+    window.top.location.href = window.self.location.href
+  }
   return (
     <>
       <Suspense fallback={null}>


### PR DESCRIPTION
Enabling [frame busting](https://en.wikipedia.org/wiki/Framekiller) will prevent traditional [clickjacking](https://en.wikipedia.org/wiki/Clickjacking) attacks in addition to social engineering attacks native to the Web3 ecosystem like the below.
___
Here, the parent window can display a series of dialogues that *appear* to be well-intentioned and prepare the victim for using the dapp (which is a familiar flow for many dapps) when in reality it sends funds to the attacker's address before redirecting the victim to the actual Uniswap app.

The below proof of concept temporarily exists at [aunyks.com/uniswap-framing](https://aunyks.com/uniswap-framing). I used Coinbase Wallet.
![uniswap-framing](https://user-images.githubusercontent.com/15711233/60319331-0a3b6000-9944-11e9-934c-9a3f3dcea011.gif)
