### PR TITLE
Allow for ETH in output command, update to 6 digits on exchange rate

### DIFF
--- a/src/components/ExchangePage/index.jsx
+++ b/src/components/ExchangePage/index.jsx
@@ -127,7 +127,11 @@ function getInitialSwapState(state) {
     independentField: state.exactFieldURL === 'output' ? OUTPUT : INPUT,
     inputCurrency: state.inputCurrencyURL ? state.inputCurrencyURL : 'ETH',
     outputCurrency: state.outputCurrencyURL
-      ? state.outputCurrencyURL
+      ? state.outputCurrencyURL === 'ETH'
+        ? state.inputCurrencyURL && state.inputCurrencyURL !== 'ETH'
+          ? 'ETH'
+          : ''
+        : state.outputCurrencyURL
       : state.initialCurrency
       ? state.initialCurrency
       : ''
@@ -707,13 +711,13 @@ export default function ExchangePage({ initialCurrency, sending = false, params 
           {inverted ? (
             <span>
               {exchangeRate
-                ? `1 ${inputSymbol} = ${amountFormatter(exchangeRate, 18, 4, false)} ${outputSymbol}`
+                ? `1 ${inputSymbol} = ${amountFormatter(exchangeRate, 18, 6, false)} ${outputSymbol}`
                 : ' - '}
             </span>
           ) : (
             <span>
               {exchangeRate
-                ? `1 ${outputSymbol} = ${amountFormatter(exchangeRateInverted, 18, 4, false)} ${inputSymbol}`
+                ? `1 ${outputSymbol} = ${amountFormatter(exchangeRateInverted, 18, 6, false)} ${inputSymbol}`
                 : ' - '}
             </span>
           )}

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -62,6 +62,8 @@ export function getAllQueryParams() {
     : ''
   params.outputCurrency = isAddress(getQueryParam(window.location, 'outputCurrency'))
     ? getQueryParam(window.location, 'outputCurrency')
+    : getQueryParam(window.location, 'outputCurrency') === 'ETH'
+    ? 'ETH'
     : ''
   params.slippage = !isNaN(getQueryParam(window.location, 'slippage')) ? getQueryParam(window.location, 'slippage') : ''
   params.exactField = getQueryParam(window.location, 'exactField')


### PR DESCRIPTION
- allow users to enter 'ETH' as output currency (only valid if input currency is set to not ETH)

- change digit display to 6 digits on exchange rate (fix for now until sig figs)