### PR TITLE
WIP: ENS name state setter expects an argument

### DIFF
--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -74,7 +74,7 @@ export function useENSName(address) {
 
       return () => {
         stale = true
-        setENSNname()
+        setENSNname(null)
       }
     }
   }, [library, address])


### PR DESCRIPTION
This PR gets rid of the following warning when using the ENS name hook in a TypeScript-flavored create-react-app env:

`Expected 1 arguments, but got 0.`