### PR TITLE
create warning and disable add liquidity button for broken tokens

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -83,5 +83,6 @@
   "decimals": "Decimals",
   "enterTokenCont": "Enter a token address to continue",
   "priceChange": "Expected price slippage",
-  "forAtLeast": "for at least "
+  "forAtLeast": "for at least ",
+  "brokenToken": "The selected token is not compatible with Uniswap. Adding liquidity will result in locked funds."
 }

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -84,5 +84,5 @@
   "enterTokenCont": "Enter a token address to continue",
   "priceChange": "Expected price slippage",
   "forAtLeast": "for at least ",
-  "brokenToken": "The selected token is not compatible with Uniswap. Adding liquidity will result in locked funds."
+  "brokenToken": "The selected token is not compatible with Uniswap V1. Adding liquidity will result in locked funds."
 }

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -9,3 +9,10 @@ export const SUPPORTED_THEMES = {
   DARK: 'DARK',
   LIGHT: 'LIGHT'
 }
+
+// list of tokens that lock fund on adding liquidity - used to disable button
+export const brokenTokens = [
+  '0xb8c77482e45f1f44de1745f52c74426c631bdd52',
+  '0x95daaab98046846bf4b2853e23cba236fa394a31',
+  '0x55296f69f40ea6d20e478533c15a6b08b654e758'
+]


### PR DESCRIPTION
- Fixes #336 

- added custom warning and disable button when trying to add liquidity for broken tokens

- using a hard coded list for now of broken tokens