### PR TITLE
Replace networkId with chainId

### DIFF
--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -182,15 +182,15 @@ export function useTokenContract(tokenAddress, withSignerIfPossible = true) {
 
 // returns null on errors
 export function useFactoryContract(withSignerIfPossible = true) {
-  const { networkId, library, account } = useWeb3React()
+  const { chainId, library, account } = useWeb3React()
 
   return useMemo(() => {
     try {
-      return getFactoryContract(networkId, library, withSignerIfPossible ? account : undefined)
+      return getFactoryContract(chainId, library, withSignerIfPossible ? account : undefined)
     } catch {
       return null
     }
-  }, [networkId, library, withSignerIfPossible, account])
+  }, [chainId, library, withSignerIfPossible, account])
 }
 
 export function useExchangeContract(exchangeAddress, withSignerIfPossible = true) {


### PR DESCRIPTION
It seems web3-react v6 uses `chainId` instead of `networkId`, but the `useFactoryContract` Hook is still deconstructing the old field. Here's a [CodeSandbox](https://codesandbox.io/s/web3-react-v6-gv56z) that proves it (see the logs).

<img width="362" alt="Capture d’écran 2019-11-27 à 16 26 50" src="https://user-images.githubusercontent.com/8782666/69731550-c20eac80-1132-11ea-82f9-a85439a67ed2.png">
