### PR TITLE
Import useWeb3React from the hooks folder

### DIFF
--- a/src/components/AccountDetails/index.js
+++ b/src/components/AccountDetails/index.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-import { useWeb3React } from '@web3-react/core'
+import { useWeb3React } from '../../hooks'
 import { isMobile } from 'react-device-detect'
 import Copy from './Copy'
 import Transaction from './Transaction'


### PR DESCRIPTION
Not sure if this is a bug, but I noticed that in all components `useWeb3React` is imported from the local hooks folder, not from the `@web3-react/core` package, except for `AccountDetails`.