### PR TITLE
Adds min-width to custom slippage input.

### DIFF
--- a/src/components/TransactionDetails/index.js
+++ b/src/components/TransactionDetails/index.js
@@ -169,6 +169,7 @@ const Input = styled.input`
   background: ${({ theme }) => theme.inputBackground};
   flex-grow: 1;
   font-size: 12px;
+  min-width: 20px;
 
   outline: none;
   box-sizing: border-box;


### PR DESCRIPTION
On Firefox (maybe other browsers as well) the lack of min-width results in the default `input` element min-width which is ~92px.  This results in the flex container overflowing the bounding element.  By setting min-width to 20px, the box will instead grow to fill the available space, which is defined by its parent that has the pink border.  This avoids the overflow issue (as long as the parent doesn't get too small, which it won't at the moment since it is fixed size).

Without `min-width` set in Firefox:
![image](https://user-images.githubusercontent.com/886059/70255784-4364df80-17c2-11ea-8ec2-97d86b7ad0d4.png)

With `min-width` set in Firefox:
![image](https://user-images.githubusercontent.com/886059/70255827-55468280-17c2-11ea-8988-0ba5720cec74.png)
