### PR TITLE
Bug fix

### DIFF
--- a/src/components/CurrencyInputPanel/index.js
+++ b/src/components/CurrencyInputPanel/index.js
@@ -577,6 +577,7 @@ function CurrencySelectModal({ isOpen, onDismiss, onTokenSelect }) {
             </TokenSymbolGroup>
           </TokenRowLeft>
           <TokenRowRight>
+            {address === '0xD24d520Eb55ea010998303110fA188673122416a' && console.log(usdBalance)}
             {balance ? (
               <TokenRowBalance>{balance && (balance > 0 || balance === '<0.0001') ? balance : '-'}</TokenRowBalance>
             ) : account ? (
@@ -585,7 +586,7 @@ function CurrencySelectModal({ isOpen, onDismiss, onTokenSelect }) {
               '-'
             )}
             <TokenRowUsd>
-              {usdBalance
+              {usdBalance && !usdBalance.isNaN()
                 ? usdBalance.isZero()
                   ? ''
                   : usdBalance.lt(0.01)

--- a/src/components/CurrencyInputPanel/index.js
+++ b/src/components/CurrencyInputPanel/index.js
@@ -577,7 +577,6 @@ function CurrencySelectModal({ isOpen, onDismiss, onTokenSelect }) {
             </TokenSymbolGroup>
           </TokenRowLeft>
           <TokenRowRight>
-            {address === '0xD24d520Eb55ea010998303110fA188673122416a' && console.log(usdBalance)}
             {balance ? (
               <TokenRowBalance>{balance && (balance > 0 || balance === '<0.0001') ? balance : '-'}</TokenRowBalance>
             ) : account ? (


### PR DESCRIPTION
- fix for #556 

- Seems like tokens with very low liquidity result in the usdBalance being populated as null (because rates use exchange reserve values)

- was able to recreate this bug with multiple exchanges with low liquidity (0xa0872ee815b8dd0f6937386fd77134720d953581 was one)