### PR TITLE
Remove stale "handleNetworkChange" function

### DIFF
--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -71,11 +71,6 @@ export function useInactiveListener(suppress = false) {
         }
       }
 
-      const handleNetworkChanged = () => {
-        // eat errors
-        activate(injected, undefined, true).catch(() => {})
-      }
-
       ethereum.on('chainChanged', handleChainChanged)
       ethereum.on('networkChanged', handleNetworkChanged)
       ethereum.on('accountsChanged', handleAccountsChanged)


### PR DESCRIPTION
I was rebasing the latest commits and I noticed this stale function.