### PR TITLE
Fix "useENSName" Hook

### DIFF
--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -158,7 +158,9 @@ export function useENSName(address) {
           }
         })
         .catch(() => {
-          setENSName(null)
+          if (!stale) {
+            setENSName(null)
+          }
         })
 
       return () => {

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -146,8 +146,9 @@ export function useENSName(address) {
   useEffect(() => {
     if (isAddress(address)) {
       let stale = false
-      try {
-        library.lookupAddress(address).then(name => {
+      library
+        .lookupAddress(address)
+        .then(name => {
           if (!stale) {
             if (name) {
               setENSName(name)
@@ -156,9 +157,9 @@ export function useENSName(address) {
             }
           }
         })
-      } catch {
-        setENSName(null)
-      }
+        .catch(() => {
+          setENSName(null)
+        })
 
       return () => {
         stale = true


### PR DESCRIPTION
When users can access the dapp only on mainnet, the "useENSName" Hook behaves correctly, but if you enable any other network, you get this error:

```
Uncaught (in promise) Error: network does not support ENS (operation="ENS", network="kovan", version=4.0.40)
    at Object.n [as throwError] (ethers.min.js:557)
    at ethers.min.js:5293
```

The reason is that ENS runs only on mainnet and the error thrown by ethers.js is never caught. The PR changes the try/ catch block with a `.catch(() => {})` handler.