### PR TITLE
Save user's wallet preference

### DIFF
--- a/src/components/AccountDetails/index.js
+++ b/src/components/AccountDetails/index.js
@@ -4,7 +4,7 @@ import { useWeb3React } from '../../hooks'
 import { isMobile } from 'react-device-detect'
 import Copy from './Copy'
 import Transaction from './Transaction'
-import { SUPPORTED_WALLETS } from '../../constants'
+import { SUPPORTED_WALLETS, WALLET_PREFERENCE_KEY } from '../../constants'
 import { ReactComponent as Close } from '../../assets/images/x.svg'
 import { getEtherscanLink } from '../../utils'
 import { injected, walletconnect, walletlink, fortmatic, portis } from '../../connectors'
@@ -315,6 +315,7 @@ export default function AccountDetails({
                   {connector !== injected && connector !== walletlink && (
                     <WalletAction
                       onClick={() => {
+                        localStorage.setItem(WALLET_PREFERENCE_KEY, '')
                         connector.close()
                       }}
                     >

--- a/src/components/WalletModal/index.js
+++ b/src/components/WalletModal/index.js
@@ -9,7 +9,7 @@ import Modal from '../Modal'
 import AccountDetails from '../AccountDetails'
 import PendingView from './PendingView'
 import Option from './Option'
-import { SUPPORTED_WALLETS } from '../../constants'
+import { SUPPORTED_WALLETS, WALLET_PREFERENCE_KEY } from '../../constants'
 import { usePrevious } from '../../hooks'
 import { Link } from '../../theme'
 import MetamaskIcon from '../../assets/images/metamask.png'
@@ -171,6 +171,8 @@ export default function WalletModal({ pendingTransactions, confirmedTransactions
     })
     setPendingWallet(connector) // set wallet for pending view
     setWalletView(WALLET_VIEWS.PENDING)
+    // Save users wallet preference in local storage if possible to reconnect
+    localStorage.setItem(WALLET_PREFERENCE_KEY, name)
     activate(connector, undefined, true).catch(error => {
       if (error instanceof UnsupportedChainIdError) {
         activate(connector) // a little janky...can't use setError because the connector isn't set

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -20,7 +20,8 @@ export const SUPPORTED_WALLETS = {
     description: 'Injected web3 provider.',
     href: null,
     color: '#010101',
-    primary: true
+    primary: true,
+    shouldReconnect: true
   },
   METAMASK: {
     connector: injected,
@@ -28,7 +29,8 @@ export const SUPPORTED_WALLETS = {
     iconName: 'metamask.png',
     description: 'Easy-to-use browser extension.',
     href: null,
-    color: '#E8831D'
+    color: '#E8831D',
+    shouldReconnect: true
   },
   WALLET_CONNECT: {
     connector: walletconnect,
@@ -36,7 +38,8 @@ export const SUPPORTED_WALLETS = {
     iconName: 'walletConnectIcon.svg',
     description: 'Connect to Trust Wallet, Rainbow Wallet and more...',
     href: null,
-    color: '#4196FC'
+    color: '#4196FC',
+    shouldReconnect: false
   },
   WALLET_LINK: {
     connector: walletlink,
@@ -44,7 +47,8 @@ export const SUPPORTED_WALLETS = {
     iconName: 'coinbaseWalletIcon.svg',
     description: 'Use Coinbase Wallet app on mobile device',
     href: null,
-    color: '#315CF5'
+    color: '#315CF5',
+    shouldReconnect: false
   },
   COINBASE_LINK: {
     name: 'Open in Coinbase Wallet',
@@ -53,7 +57,8 @@ export const SUPPORTED_WALLETS = {
     href: 'https://go.cb-w.com/mtUDhEZPy1',
     color: '#315CF5',
     mobile: true,
-    mobileOnly: true
+    mobileOnly: true,
+    shouldReconnect: false
   },
   TRUST_WALLET_LINK: {
     name: 'Open in Trust Wallet',
@@ -62,7 +67,8 @@ export const SUPPORTED_WALLETS = {
     href: 'https://link.trustwallet.com/open_url?coin_id=60&url=https://uniswap.exchange/swap',
     color: '#1C74CC',
     mobile: true,
-    mobileOnly: true
+    mobileOnly: true,
+    shouldReconnect: false
   },
   FORTMATIC: {
     connector: fortmatic,
@@ -71,7 +77,8 @@ export const SUPPORTED_WALLETS = {
     description: 'Login using Fortmatic hosted wallet',
     href: null,
     color: '#6748FF',
-    mobile: true
+    mobile: true,
+    shouldReconnect: false // Currently, Fortmatic shows a rate limit error when this is enabled but it should be possible
   },
   Portis: {
     connector: portis,
@@ -80,7 +87,8 @@ export const SUPPORTED_WALLETS = {
     description: 'Login using Portis hosted wallet',
     href: null,
     color: '#4A6C9B',
-    mobile: true
+    mobile: true,
+    shouldReconnect: true
   }
 }
 
@@ -92,3 +100,5 @@ export const brokenTokens = [
 ]
 
 export const NetworkContextName = 'NETWORK'
+
+export const WALLET_PREFERENCE_KEY = 'wallet_preference'

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -40,7 +40,7 @@ export function useEagerConnect() {
         return
       }
     }
-    
+
     // Use the injected wallet if it is authorized
     injected.isAuthorized().then(isAuthorized => {
       if (isAuthorized) {


### PR DESCRIPTION
This pull request adds the ability to store the user's wallet preference (the last wallet they used). When a user refreshes the page or visits Uniswap again, their preferred wallet will reconnect when possible. The following supported wallets can reconnect:
* Injected wallets
* Portis
* Fortmatic (currently a rate limit error is shown when reconnecting. This error must be solved first.)

Also, when a browser blocks pop ups, wallets like Authereum will fallback to redirecting to the wallet's domain for authentication and then redirecting back to Uniswap. This PR will ensure the user does not have to click "Connect a wallet" a second time to connect after being redirected.

To try functionality:
* Log in with Portis or Fortmatic
* Refresh the page
* You will still be logged in to the selected wallet or will be asked to authenticate if you have logged out of that wallet