### PR TITLE
Prioritize exact token symbol matches

### DIFF
--- a/src/components/CurrencyInputPanel/index.js
+++ b/src/components/CurrencyInputPanel/index.js
@@ -568,7 +568,12 @@ function CurrencySelectModal({ isOpen, onDismiss, onTokenSelect, urlAddedTokens 
       })
       return regexMatches.some(m => m)
     })
-    return searchQuery.toUpperCase() === 'DAI' && list.sort((a, b) => { return a.symbol === 'DAI' ? -1 : 1 })
+    return (
+      searchQuery.toUpperCase() === 'DAI' &&
+      list.sort((a, b) => {
+        return a.symbol === 'DAI' ? -1 : 1
+      })
+    )
   }, [tokenList, searchQuery])
 
   function _onTokenSelect(address) {

--- a/src/components/CurrencyInputPanel/index.js
+++ b/src/components/CurrencyInputPanel/index.js
@@ -594,9 +594,9 @@ function CurrencySelectModal({ isOpen, onDismiss, onTokenSelect, urlAddedTokens 
       return <TokenModalInfo>{t('noExchange')}</TokenModalInfo>
     }
 
-    if (searchQuery === "DAI") {
+    if (searchQuery === 'DAI') {
       filteredTokenList.sort((a, b) => {
-        return a.symbol === "DAI" ? -1 : 1;
+        return a.symbol === 'DAI' ? -1 : 1
       })
     }
 

--- a/src/components/CurrencyInputPanel/index.js
+++ b/src/components/CurrencyInputPanel/index.js
@@ -594,6 +594,12 @@ function CurrencySelectModal({ isOpen, onDismiss, onTokenSelect, urlAddedTokens 
       return <TokenModalInfo>{t('noExchange')}</TokenModalInfo>
     }
 
+    if (searchQuery === "DAI") {
+        filteredTokenList.sort((a, b) => {
+            console.log(a.symbol === "DAI")
+            return a.symbol === "DAI" ? -1 : 1;
+        })
+    }
     return filteredTokenList.map(({ address, symbol, name, balance, usdBalance }) => {
       const urlAdded = urlAddedTokens && urlAddedTokens.hasOwnProperty(address)
       const customAdded =

--- a/src/components/CurrencyInputPanel/index.js
+++ b/src/components/CurrencyInputPanel/index.js
@@ -595,11 +595,11 @@ function CurrencySelectModal({ isOpen, onDismiss, onTokenSelect, urlAddedTokens 
     }
 
     if (searchQuery === "DAI") {
-        filteredTokenList.sort((a, b) => {
-            console.log(a.symbol === "DAI")
-            return a.symbol === "DAI" ? -1 : 1;
-        })
+      filteredTokenList.sort((a, b) => {
+        return a.symbol === "DAI" ? -1 : 1;
+      })
     }
+
     return filteredTokenList.map(({ address, symbol, name, balance, usdBalance }) => {
       const urlAdded = urlAddedTokens && urlAddedTokens.hasOwnProperty(address)
       const customAdded =

--- a/src/components/CurrencyInputPanel/index.js
+++ b/src/components/CurrencyInputPanel/index.js
@@ -548,7 +548,7 @@ function CurrencySelectModal({ isOpen, onDismiss, onTokenSelect, urlAddedTokens 
   }, [allBalances, allTokens, usdAmounts, account])
 
   const filteredTokenList = useMemo(() => {
-    return tokenList.filter(tokenEntry => {
+    const list = tokenList.filter(tokenEntry => {
       const inputIsAddress = searchQuery.slice(0, 2) === '0x'
 
       // check the regex for each field
@@ -568,6 +568,7 @@ function CurrencySelectModal({ isOpen, onDismiss, onTokenSelect, urlAddedTokens 
       })
       return regexMatches.some(m => m)
     })
+    return searchQuery.toUpperCase() === 'DAI' && list.sort((a, b) => { return a.symbol === 'DAI' ? -1 : 1 })
   }, [tokenList, searchQuery])
 
   function _onTokenSelect(address) {
@@ -592,12 +593,6 @@ function CurrencySelectModal({ isOpen, onDismiss, onTokenSelect, urlAddedTokens 
     }
     if (!filteredTokenList.length) {
       return <TokenModalInfo>{t('noExchange')}</TokenModalInfo>
-    }
-
-    if (searchQuery === 'DAI') {
-      filteredTokenList.sort((a, b) => {
-        return a.symbol === 'DAI' ? -1 : 1
-      })
     }
 
     return filteredTokenList.map(({ address, symbol, name, balance, usdBalance }) => {

--- a/src/components/CurrencyInputPanel/index.js
+++ b/src/components/CurrencyInputPanel/index.js
@@ -568,12 +568,11 @@ function CurrencySelectModal({ isOpen, onDismiss, onTokenSelect, urlAddedTokens 
       })
       return regexMatches.some(m => m)
     })
-    return (
-      searchQuery.toUpperCase() === 'DAI' &&
-      list.sort((a, b) => {
-        return a.symbol === 'DAI' ? -1 : 1
-      })
-    )
+    // If the user has not inputted anything, preserve previous sort
+    if (searchQuery === '') return list
+    return list.sort((a, b) => {
+      return a.symbol.toLowerCase() === searchQuery.toLowerCase() ? -1 : 1
+    })
   }, [tokenList, searchQuery])
 
   function _onTokenSelect(address) {


### PR DESCRIPTION
This adds an opinionated sort to the `filteredTokenList` to prioritize `DAI` when a user inputs `DAI` into the token search.

Previous:
<img width="760" alt="Screen Shot 2020-02-12 at 10 06 42" src="https://user-images.githubusercontent.com/16929357/74353831-79a57900-4d88-11ea-8801-aa38ab15a08d.png">

New:
<img width="737" alt="Screen Shot 2020-02-12 at 11 10 01" src="https://user-images.githubusercontent.com/16929357/74353848-7f9b5a00-4d88-11ea-81fb-b4c32d6b7055.png">


