### PR TITLE
Update local env setup documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Rename `.env.local.example` to `.env.local` and fill in the appropriate variable
 yarn start
 ```
 
-To run on a testnet, make a copy of `.env.local.example` named `.env.local`, change `REACT_APP_NETWORK_ID` to `"{yourNetworkId}"`, and change `REACT_APP_NETWORK_URL` to e.g. `"https://{yourNetwork}.infura.io/v3/{yourKey}"`.
+To run on a testnet, make a copy of `.env.local.example` named `.env.local`, change `REACT_APP_CHAIN_ID` to `"{yourChainId}"`, and change `REACT_APP_NETWORK_URL` to e.g. `"https://{yourNetwork}.infura.io/v3/{yourKey}"`.
 
 If deploying with Github Pages, be aware that there's some [tricky client-side routing behavior with `create-react-app`](https://create-react-app.dev/docs/deployment#notes-on-client-side-routing).
 


### PR DESCRIPTION
Hey all, was setting up the frontend locally and noticed that the variable change in the `.env.local.example` (from #621) renamed `REACT_APP_NETWORK_ID` to `REACT_APP_CHAIN_ID` but the README still references the old variable name so addressing that documentation fix here