### PR TITLE
change results height on search modal

### DIFF
--- a/src/components/SearchModal/index.tsx
+++ b/src/components/SearchModal/index.tsx
@@ -47,7 +47,7 @@ const TokenModalInfo = styled.div`
 
 const ItemList = styled.div`
   flex-grow: 1;
-  height: 240px;
+  height: 254px;
   overflow-y: scroll;
   -webkit-overflow-scrolling: touch;
 `


### PR DESCRIPTION
- Show part of the next token to indicate to user that list is scrollable