### PR TITLE
Expert mode 

### DIFF
--- a/src/components/Toggle/index.tsx
+++ b/src/components/Toggle/index.tsx
@@ -1,0 +1,46 @@
+import React from 'react'
+import styled from 'styled-components'
+
+const ToggleElement = styled.span<{ isActive?: boolean; on?: boolean }>`
+  padding: 0.25rem 0.5rem;
+  border-radius: 14px;
+  background: ${({ theme, isActive, on }) => (isActive ? (on ? theme.primary1 : theme.text5) : 'none')};
+  color: ${({ theme, isActive, on }) => (isActive ? (on ? theme.white : theme.text2) : theme.text3)};
+  font-size: 0.825rem;
+  font-weight: 400;
+  /* :hover {
+    user-select: ${({ isActive }) => (isActive ? 'none' : 'initial')};
+    background: ${({ theme, isActive }) => (isActive ? theme.primary1 : 'none')};
+    color: ${({ theme, isActive }) => (isActive ? theme.white : theme.primary3)};
+  } */
+`
+
+const StyledToggle = styled.a<{ isActive?: boolean; activeElement?: boolean }>`
+  border-radius: 16px;
+  border: 1px solid ${({ theme, isActive }) => (isActive ? theme.primary5 : theme.text5)};
+  display: flex;
+  width: fit-content;
+  cursor: pointer;
+  text-decoration: none;
+  :hover {
+    text-decoration: none;
+  }
+`
+
+export interface ToggleProps {
+  isActive: boolean
+  toggle: () => void
+}
+
+export default function Toggle({ isActive, toggle }: ToggleProps) {
+  return (
+    <StyledToggle isActive={isActive} target="_self" onClick={toggle}>
+      <ToggleElement isActive={isActive} on={true}>
+        On
+      </ToggleElement>
+      <ToggleElement isActive={!isActive} on={false}>
+        Off
+      </ToggleElement>
+    </StyledToggle>
+  )
+}

--- a/src/components/swap/AdvancedSwapDetails.tsx
+++ b/src/components/swap/AdvancedSwapDetails.tsx
@@ -11,15 +11,19 @@ import { SectionBreak } from './styleds'
 import QuestionHelper from '../QuestionHelper'
 import { RowBetween, RowFixed } from '../Row'
 import SlippageTabs, { SlippageTabsProps } from '../SlippageTabs'
+import Toggle from '../Toggle'
 import FormattedPriceImpact from './FormattedPriceImpact'
 import TokenLogo from '../TokenLogo'
 import flatMap from 'lodash.flatmap'
+import { useExpertModeManager } from '../../state/user/hooks'
 
 function TradeSummary({ trade, allowedSlippage }: { trade: Trade; allowedSlippage: number }) {
   const theme = useContext(ThemeContext)
   const { priceImpactWithoutFee, realizedLPFee } = computeTradePriceBreakdown(trade)
   const isExactIn = trade.tradeType === TradeType.EXACT_INPUT
   const slippageAdjustedAmounts = computeSlippageAdjustedAmounts(trade, allowedSlippage)
+
+  const [expertMode, toggleExpertMode] = useExpertModeManager()
 
   return (
     <>
@@ -135,6 +139,17 @@ export function AdvancedSwapDetails({ trade, onDismiss, ...slippageTabProps }: A
           </Flex>
         </AutoColumn>
       )}
+      <SectionBreak />
+
+      <RowBetween padding={'0 20px 4px 20px'}>
+        <RowFixed>
+          <TYPE.black fontWeight={400} fontSize={14} color={theme.text2}>
+            Toggle Expert Mode
+          </TYPE.black>
+          <QuestionHelper text="Bypasses swap confirm modals. Use at your own risk." />
+        </RowFixed>
+        <Toggle isActive={expertMode} toggle={toggleExpertMode} />
+      </RowBetween>
     </AutoColumn>
   )
 }

--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -26,6 +26,8 @@ import { useActiveWeb3React } from '../../hooks'
 import { useApproveCallbackFromTrade, ApprovalState } from '../../hooks/useApproveCallback'
 import { useSwapCallback } from '../../hooks/useSwapCallback'
 import { useWalletModalToggle } from '../../state/application/hooks'
+import { useExpertModeManager } from '../../state/user/hooks'
+
 import { Field } from '../../state/swap/actions'
 import {
   useDefaultsFromURLSearch,
@@ -46,6 +48,7 @@ export default function Swap({ location: { search } }: RouteComponentProps) {
 
   // toggle wallet when disconnected
   const toggleWalletModal = useWalletModalToggle()
+  const [expertMode] = useExpertModeManager()
 
   // swap state
   const { independentField, typedValue } = useSwapState()
@@ -122,7 +125,7 @@ export default function Swap({ location: { search } }: RouteComponentProps) {
     }
     setPendingConfirmation(true)
     setAttemptingTxn(false)
-    setShowAdvanced(false)
+    // setShowAdvanced(false)
   }
 
   // the callback to execute the swap
@@ -134,6 +137,8 @@ export default function Swap({ location: { search } }: RouteComponentProps) {
     if (priceImpactWithoutFee && !confirmPriceImpactWithoutFee(priceImpactWithoutFee)) {
       return
     }
+
+    console.log('trying to swap?')
 
     setAttemptingTxn(true)
     swapCallback().then(hash => {
@@ -324,7 +329,7 @@ export default function Swap({ location: { search } }: RouteComponentProps) {
             ) : (
               <ButtonError
                 onClick={() => {
-                  setShowConfirm(true)
+                  expertMode ? onSwap() : setShowConfirm(true)
                 }}
                 id="swap-button"
                 disabled={!isValid}

--- a/src/state/user/actions.ts
+++ b/src/state/user/actions.ts
@@ -16,6 +16,7 @@ export interface SerializedPair {
 export const updateVersion = createAction<void>('updateVersion')
 export const updateMatchesDarkMode = createAction<{ matchesDarkMode: boolean }>('updateMatchesDarkMode')
 export const updateUserDarkMode = createAction<{ userDarkMode: boolean }>('updateUserDarkMode')
+export const updateUserExpertMode = createAction<{ userExpertMode: boolean }>('updateUserExpertMode')
 export const addSerializedToken = createAction<{ serializedToken: SerializedToken }>('addSerializedToken')
 export const removeSerializedToken = createAction<{ chainId: number; address: string }>('removeSerializedToken')
 export const addSerializedPair = createAction<{ serializedPair: SerializedPair }>('addSerializedPair')

--- a/src/state/user/reducer.ts
+++ b/src/state/user/reducer.ts
@@ -10,7 +10,8 @@ import {
   SerializedToken,
   updateMatchesDarkMode,
   updateUserDarkMode,
-  updateVersion
+  updateVersion,
+  updateUserExpertMode
 } from './actions'
 
 const currentTimestamp = () => new Date().getTime()
@@ -20,6 +21,8 @@ interface UserState {
 
   userDarkMode: boolean | null // the user's choice for dark mode or light mode
   matchesDarkMode: boolean // whether the dark mode media query matches
+
+  userExpertMode: boolean
 
   tokens: {
     [chainId: number]: {
@@ -54,6 +57,8 @@ const initialState: UserState = {
   userDarkMode: null,
   matchesDarkMode: false,
 
+  userExpertMode: false,
+
   tokens: {},
   pairs: {},
 
@@ -84,6 +89,10 @@ export default createReducer(initialState, builder =>
     })
     .addCase(updateMatchesDarkMode, (state, action) => {
       state.matchesDarkMode = action.payload.matchesDarkMode
+      state.timestamp = currentTimestamp()
+    })
+    .addCase(updateUserExpertMode, (state, action) => {
+      state.userExpertMode = action.payload.userExpertMode
       state.timestamp = currentTimestamp()
     })
     .addCase(addSerializedToken, (state, { payload: { serializedToken } }) => {


### PR DESCRIPTION
Start of expert mode.

Todo:

 use browser alert box to force user to type "confirm" when turning on
 Add a cool icon to your account in the header to indicate you are an expert 🥇
 Fire a "transaction submitted" notification when successful only if confirm modal is bypassed
 Decide where the toggle should go
 Decide whether we need or want this - or if a "cleaner" solution is possible